### PR TITLE
Add custom message param to lost connection screen

### DIFF
--- a/lib/bluetooth/BluetoothLostConnectionScreen.tsx
+++ b/lib/bluetooth/BluetoothLostConnectionScreen.tsx
@@ -7,16 +7,16 @@ import {View} from 'react-native';
  * This screen can be used when the BLE connection has been lost, to warn the user, and allow her to reconnect.
  * @category Bluetooth
  */
-export function GetBluetoothLostConnectionScreen(reconnectScreen: string) {
+export function GetBluetoothLostConnectionScreen(
+    reconnectScreen: string,
+    message = 'Your device has lost its Bluetooth connection. Please reconnect to continue using the app.',
+) {
     return ({navigation}: {navigation: any}) => {
         // --- view
         return (
             <BottomView headerTitle="Loss of connection with the device" onClose={() => navigation.popToTop()}>
                 <View className="flex-1">
-                    <Txt>
-                        Your device has lost its Bluetooth connection. Please reconnect to continue using the app. To reconnect, confirm the
-                        connection using the remote control.
-                    </Txt>
+                    <Txt>{message}</Txt>
                 </View>
                 <Button variant="default" onPress={() => navigation.replace(reconnectScreen)}>
                     <Txt>Reconnect via Bluetooth</Txt>


### PR DESCRIPTION
- Added custom message param to `GetBluetoothLostConnectionScreen`
- Removed mention of "remote control" from default message 